### PR TITLE
Change `StatusCode` type to `ContentfulStatusCode`

### DIFF
--- a/src/middlewares/on-error.ts
+++ b/src/middlewares/on-error.ts
@@ -1,5 +1,5 @@
 import type { ErrorHandler } from "hono";
-import type { StatusCode } from "hono/utils/http-status";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 import { INTERNAL_SERVER_ERROR, OK } from "../http-status-codes.js";
 
@@ -8,7 +8,7 @@ const onError: ErrorHandler = (err, c) => {
     ? err.status
     : c.newResponse(null).status;
   const statusCode = currentStatus !== OK
-    ? (currentStatus as StatusCode)
+    ? (currentStatus as ContentfulStatusCode)
     : INTERNAL_SERVER_ERROR;
   // eslint-disable-next-line node/prefer-global/process
   const env = c.env?.NODE_ENV || process.env?.NODE_ENV;


### PR DESCRIPTION
In the `onError` handler, returning a `c.json()` response with a contentless status code will throw a type error, as `c.json()` requires content. This behavior was introduced in Hono [v4.6.15](https://github.com/honojs/hono/releases/tag/v4.6.15).

To address this, changing the `StatusCode` type to `ContentfulStatusCode` in the `onError` handler should resolve the issue. However, can we safely assume that `currentStatus` is always a valid status code? Would it be better to maintain an array of valid status codes to check against, rather than simply casting `currentStatus` to `ContentfulStatusCode`?