### PR TITLE
fix(openapi): generate clean example object in createErrorSchema for proper OpenAPI validation

### DIFF
--- a/src/openapi/helpers/types.ts
+++ b/src/openapi/helpers/types.ts
@@ -3,3 +3,4 @@ import type { z } from "@hono/zod-openapi";
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-expect-error
 export type ZodSchema = z.ZodUnion | z.AnyZodObject | z.ZodArray<z.AnyZodObject>;
+export type ZodIssue = z.ZodIssue;


### PR DESCRIPTION
### What’s Changed

This PR improves the `createErrorSchema` function used for generating error response schemas from Zod. Previously, the `.openapi({ example })` value was a raw `ZodError` instance returned by `schema.safeParse()`. This included non-serializable or extraneous properties, which caused tools like Spectral to raise validation errors:

> "example" property must have required property "issues"  
> spectral(oas3-valid-schema-example)

### Fix

The new implementation maps the `ZodError` into a clean JSON object with only the relevant fields:

```ts
{
  name: error.name,
  issues: error.issues.map(issue => ({
    code: issue.code,
    path: issue.path,
    message: issue.message,
  })),
}
```

If no error is returned (e.g. schema passes), a fallback example with a typical validation error structure is provided.
Why It Matters

This change ensures the OpenAPI examples are valid, minimal, and compatible with tools like Spectral and SwaggerUI validators. It also improves the developer experience when generating schemas with @hono/zod-openapi.

Let me know if you'd like changes, happy to adjust to fit the project direction.

---

Let me know if you want to include screenshots of validation errors before/after or if you're also updating tests/docs alongside this.
