### PR TITLE
feature(multipart/form-data): adding multipart/form-data helpers and file upload schema

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@ packages:
   - docs
   - packages/*
   - examples/*
+
+onlyBuiltDependencies:
+  - esbuild
+  - simple-git-hooks

--- a/src/openapi/helpers/index.ts
+++ b/src/openapi/helpers/index.ts
@@ -1,4 +1,6 @@
 export { default as jsonContentOneOf } from "./json-content-one-of.js";
 export { default as jsonContentRequired } from "./json-content-required.js";
 export { default as jsonContent } from "./json-content.js";
+export { default as multipartContentRequired } from "./multipart-content-required.js";
+export { default as multipartContent } from "./multipart-content.js";
 export { default as oneOf } from "./one-of.js";

--- a/src/openapi/helpers/multipart-content-required.ts
+++ b/src/openapi/helpers/multipart-content-required.ts
@@ -1,0 +1,16 @@
+import type { ZodSchema } from "./types.js";
+
+import multipartContent from "./multipart-content.js";
+
+const multipartContentRequired = <
+  T extends ZodSchema,
+>(schema: T,
+  description: string,
+) => {
+  return {
+    ...multipartContent(schema, description),
+    required: true,
+  };
+};
+
+export default multipartContentRequired;

--- a/src/openapi/helpers/multipart-content.ts
+++ b/src/openapi/helpers/multipart-content.ts
@@ -1,0 +1,18 @@
+import type { ZodSchema } from "./types.js";
+
+const multipartContent = <
+  T extends ZodSchema,
+>(schema: T,
+  description: string,
+) => {
+  return {
+    content: {
+      "mulitpart/form-data": {
+        schema,
+      },
+    },
+    description,
+  };
+};
+
+export default multipartContent;

--- a/src/openapi/schemas/file-upload-schema.ts
+++ b/src/openapi/schemas/file-upload-schema.ts
@@ -1,0 +1,10 @@
+import { z } from "@hono/zod-openapi";
+
+const FileUploadSchema = z.object({
+  file: z.file().openapi({
+    example: "test.png",
+    type: "object",
+  }),
+});
+
+export default FileUploadSchema;

--- a/src/openapi/schemas/index.ts
+++ b/src/openapi/schemas/index.ts
@@ -1,5 +1,6 @@
 export { default as createErrorSchema } from "./create-error-schema.js";
 export { default as createMessageObjectSchema } from "./create-message-object.js";
+export { default as FileUploadSchema } from "./file-upload-schema.js";
 export { default as IdParamsSchema } from "./id-params.js";
 export { default as IdUUIDParamsSchema } from "./id-uuid-params.js";
 export { default as SlugParamsSchema } from "./slug-params.js";


### PR DESCRIPTION
### What’s Changed

This PR adds the `multipartContent` and `multipartContentRequired` used with `"mulitpart/form-data"` for adding content request schemas from zod-openapi. This was structured replicating existing `jsonContent` to keep uniformity in the library.
A FileUploadSchema was added to mostly as a demonstration. 

### ⚠️ Lookout!
```ts
const FileUploadSchema = z.object({
  file: z.file().openapi({
    example: "test.png",
    type: "object",
  }),
});
```
`type: "object"` in `.openapi({})` is crucial to properly generate openapi doc.

---

This change ensures the OpenAPI examples are valid, minimal, and compatible with tools like Scalar validators. It also improves the developer experience when generating schemas with @hono/zod-openapi.

Let me know if you'd like changes, happy to adjust to fit the project direction.